### PR TITLE
digest combined LTR and RTL words

### DIFF
--- a/modules/util/svg_paths_arabic_fix.js
+++ b/modules/util/svg_paths_arabic_fix.js
@@ -59,56 +59,59 @@ const chars = {
 };
 
 export function fixArabicScriptTextForSvg(inputText){
-    return inputText.split(' ').reverse().map(function(w){
-        return fixArabicScriptWordForSvg(w);
-    }).join(' ');
-}
-
-export function fixArabicScriptWordForSvg(inputWord){    
     let context = true;
-    let ret = [];
-    //const inputWord = inputWord.split('');
-    for(let i = 0, l = inputWord.length; i < l; i++){
-        let code = inputWord[i].charCodeAt(0);
-        let nextCode = inputWord[i + 1] ? inputWord[i + 1].charCodeAt(0) : 0;
-        if(!chars[code]){             
-            ret.push(inputWord[i]);
+    let ret = '';
+    let rtlBuffer = [];
+
+    for(let i = 0, l = inputText.length; i < l; i++){
+        let code = inputText[i].charCodeAt(0);
+        let nextCode = inputText[i + 1] ? inputText[i + 1].charCodeAt(0) : 0;
+        if(!chars[code]){
+            if (code === 32 && rtlBuffer.length) {
+              // whitespace
+              rtlBuffer = [rtlBuffer.reverse().join('') + ' '];
+            } else {
+              // non-RTL character
+              ret += rtlBuffer.reverse().join('') + inputText[i];
+              rtlBuffer = [];
+            }
             continue;
         }                
         if(context){            
             if(i == l - 1){                
-                ret.push(chars[code].isolated);
+                rtlBuffer.push(chars[code].isolated);
             } else {
                 // special case for لا
                 if(code == 1604 && nextCode == 1575){
-                    ret.push(chars[5000].initial);
+                    rtlBuffer.push(chars[5000].initial);
                     i++;
                     context = true;
                     continue;
                 }
 
-                ret.push(chars[code].initial);
+                rtlBuffer.push(chars[code].initial);
             }            
         } else {
             if(i == l - 1){                
-                ret.push(chars[code].final);
+                rtlBuffer.push(chars[code].final);
             } else {
                 // special case for ﻼ
                 if(code == 1604 && nextCode == 1575){
-                    ret.push(chars[5000].final);
+                    rtlBuffer.push(chars[5000].final);
                     i++;
                     context = true;
                     continue;
                 }
                 if(chars[code].medial == ''){                    
-                    ret.push(chars[code].final);
+                    rtlBuffer.push(chars[code].final);
                 } else{                    
-                    ret.push(chars[code].medial);
+                    rtlBuffer.push(chars[code].medial);
                 }                
             }
         }        
         context = (chars[code].medial == '');        
     }   
+    ret += rtlBuffer.reverse().join('');
     
-    return ret.reverse().join('');
+    return ret;
 }


### PR DESCRIPTION
Here's how it works:

- right-to-left letters are added up in a rtlBuffer which will eventually be reversed
- if it hits a whitespace in an Arabic context, the space is included in the rtlBuffer so that the Arabic words will be shown in the right order
- if it hits a LTR letter, it writes out the existing Arabic words and starts writing the new characters left-to-right (this includes the numerals used in Persian and Arabic, which are written LTR)
- if it hits a whitespace in a LTR context, it doesn't add it to the buffer (so roads labeled NAME ARABIC_NAME will keep a space)